### PR TITLE
[Fix] - #102 관극기록 삭제할 때 리뷰를 먼저 삭제하여 데이터가 부유하지 않게 하기 

### DIFF
--- a/YeonMuLog/Data/Repository/UserPlayRepository.swift
+++ b/YeonMuLog/Data/Repository/UserPlayRepository.swift
@@ -12,7 +12,7 @@ fileprivate protocol UserPlayRepositoryType: AnyObject {
     func fetch() -> Results<UserPlayInfo>
     func createPlay(_ item: UserPlayInfo)
     func updatePlay(_ item: UserPlayInfo)
-    func deleteMemo(_ item: UserPlayInfo)
+    func deletePlay(_ item: UserPlayInfo)
     
     func updateReview(_ item: UserPlayInfo)
 }
@@ -74,7 +74,7 @@ class UserPlayRepository {
         }
     }
     
-    func deleteMemo(_ item: UserPlayInfo) {
+    func deletePlay(_ item: UserPlayInfo) {
         do {
             try localRealm.write {
                 localRealm.delete(item.userReview)

--- a/YeonMuLog/Data/Repository/UserPlayRepository.swift
+++ b/YeonMuLog/Data/Repository/UserPlayRepository.swift
@@ -77,6 +77,7 @@ class UserPlayRepository {
     func deleteMemo(_ item: UserPlayInfo) {
         do {
             try localRealm.write {
+                localRealm.delete(item.userReview)
                 localRealm.delete(item)
             }
         } catch let error {

--- a/YeonMuLog/Presentations/TaraeDetail/TaraeDetailViewController.swift
+++ b/YeonMuLog/Presentations/TaraeDetail/TaraeDetailViewController.swift
@@ -78,7 +78,7 @@ class TaraeDetailViewController: BaseViewController {
                 
                 let remove = UIAlertAction(title: "삭제", style: .destructive) { _ in
                     if let playInfo = self.playInfo {
-                        self.repository.deleteMemo(playInfo)
+                        self.repository.deletePlay(playInfo)
                         self.mainView.makeToast("삭제되었습니다.", duration: 1.0, position: .top, title: nil, image: nil, style: ToastStyle()) { didTap in
                             self.navigationController?.popViewController(animated: true)
                         }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- fix/#102

### 💡 **Motivation**
관극기록 삭제할 때 리뷰를 먼저 삭제하여 데이터가 부유하지 않게 하기 

### 🔑 **Key Changes**
관극기록 삭제할 때 리뷰를 먼저 삭제하여 데이터가 부유하지 않게 하기 

### Relevant Issue(s)
- #102
