### PR TITLE
[Fix] #97 리뷰 추가 시 사용자 인터랙션을 비활성화하여 중복 저장을 막도록 하기 

### DIFF
--- a/YeonMuLog/Presentations/AddReview/AddReviewViewController.swift
+++ b/YeonMuLog/Presentations/AddReview/AddReviewViewController.swift
@@ -91,7 +91,7 @@ class AddReviewViewController: BaseViewController {
             }
             repository.updateReview(playInfo!, review: review)
             
-            // 완료 토스트 
+            // 완료 토스트
             showFinishToast(title: "리뷰 추가 성공!", message: "리뷰가 성공적으로 저장되었습니다.", imageName: "character-pencil-finished") { _ in
                 self.delegate?.reviewDataReload()
                 self.dismiss(animated: true)
@@ -118,7 +118,7 @@ class AddReviewViewController: BaseViewController {
         style.imageSize = CGSize(width: 80, height: 80)
         style.titleFont = .appleSDGothicNeo(of: .subTitle, weight: .medium)
         style.messageFont = .appleSDGothicNeo(of: .content, weight: .regular)
-        self.mainView.makeToast(message, duration: 1.0, position: .bottom, title: title, image: UIImage(named: imageName), style: style, completion: completion)
+        self.mainView.makeToast(message, duration: 0.8, position: .bottom, title: title, image: UIImage(named: imageName), style: style, completion: completion)
         
     }
     

--- a/YeonMuLog/Presentations/AddReview/AddReviewViewController.swift
+++ b/YeonMuLog/Presentations/AddReview/AddReviewViewController.swift
@@ -78,6 +78,10 @@ class AddReviewViewController: BaseViewController {
     @objc func finishReviewButtonTapped(_ sender: UIButton) {
         
         if playInfo != nil && !mainView.userTextView.text.trimmingCharacters(in: .whitespaces).isEmpty {
+            // 사용자 인터랙션 비활성화
+            self.mainView.isUserInteractionEnabled = false
+            
+            // 저장
             let review = UserReview()
             review.text = mainView.userTextView.text
             review.voice = voiceMemo
@@ -85,11 +89,17 @@ class AddReviewViewController: BaseViewController {
             if !image.isEmpty {
                 review.image.append(objectsIn: image)
             }
-            
             repository.updateReview(playInfo!, review: review)
+            
+            // 완료 토스트 
             showFinishToast(title: "리뷰 추가 성공!", message: "리뷰가 성공적으로 저장되었습니다.", imageName: "character-pencil-finished") { _ in
                 self.delegate?.reviewDataReload()
                 self.dismiss(animated: true)
+                
+                // 사용자 인터랙션 재활성화
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    self.mainView.isUserInteractionEnabled = true
+                }
             }
             
         } else {


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- fix/#97

### 💡 **Motivation**
리뷰 추가 시 사용자 인터랙션을 비활성화하여 중복 저장을 막도록 하기 

### 🔑 **Key Changes**
- 완료 메시지 뜨기 전 뷰의 사용자 인터랙션 비활성화
- 완료 메시지 뜬 후 2초 뒤에 사용자 인터랙션 재활성화 


🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 리뷰 저장  | ![Simulator Screen Recording - iPhone 11 - 2022-10-26 at 00 40 57](https://user-images.githubusercontent.com/51395335/197819591-ca70d787-fbec-48fc-a3af-5ff91ed0acb2.gif) |

### Relevant Issue(s)
- #97 
