### PR TITLE
[Feat] #103 타래보기 스와이프 트레일링 액션으로 삭제 추가

### DIFF
--- a/YeonMuLog/Presentations/Tarae/TaraeViewController.swift
+++ b/YeonMuLog/Presentations/Tarae/TaraeViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import RealmSwift
+import Toast
 
 class TaraeViewController: BaseViewController {
     // MARK: - Properties
@@ -108,5 +109,31 @@ extension TaraeViewController: UITableViewDelegate, UITableViewDataSource {
             vc.playInfo = list[indexPath.row]
             navigationController?.pushViewController(vc, animated: true)
         }
+    }
+    
+    // Swipe Action
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
+        let delete = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, _ in
+            
+            let remove = UIAlertAction(title: "삭제", style: .destructive) { _ in
+                if let item = self?.list[indexPath.row] {
+                    
+                    self?.repository.deletePlay(item)
+                    self?.mainView.makeToast("관극기록이 삭제되었습니다.", duration: 1.0, position: .center, title: nil, image: nil, style: ToastStyle(), completion: nil)
+                    
+                    self?.list = self?.repository.fetch()
+                }
+            }
+            
+            let cancel = UIAlertAction(title: "취소", style: .cancel)
+            
+            self?.showAlert(title: "관극기록을 삭제하시겠습니까?", message: "삭제하시면 리뷰도 전부 삭제됩니다", actions: remove, cancel)
+            
+        }
+        delete.image = UIImage(systemName: "trash.fill")
+        delete.backgroundColor = .systemRed
+        
+        return UISwipeActionsConfiguration(actions: [delete])
     }
 }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- feature/#103

### 💡 **Motivation**
타래보기 스와이프 트레일링 액션으로 삭제 추가

### 🔑 **Key Changes**
- 트레일링 액션으로 삭제 시 안내 얼럿 보여주기
- 얼럿에서 확인 선택 시 관극기록 삭제 후 리스트 새로 불러오기
- 취소 누를 경우 아무 액션도 하지 않음  

🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 스와이프 트레일링 액션 | ![Simulator Screen Recording - iPhone 11 - 2022-10-28 at 00 17 15](https://user-images.githubusercontent.com/51395335/198330024-a09a43f2-54b1-4cb1-8108-7663e9875f17.gif)  |

### Relevant Issue(s)
- #103
