### PR TITLE
[Feature] #108 날짜순, 극 가나다순으로 정렬버튼 만들기

### DIFF
--- a/YeonMuLog/Data/Repository/UserPlayRepository.swift
+++ b/YeonMuLog/Data/Repository/UserPlayRepository.swift
@@ -8,12 +8,19 @@
 import Foundation
 import RealmSwift
 
+enum SortOption: String {
+    case date = "date"
+    case userReview = "userReview"
+    case title = "title"
+}
+
 fileprivate protocol UserPlayRepositoryType: AnyObject {
     func fetch() -> Results<UserPlayInfo>
+    func fetchWith(sort: SortOption, option: Bool) -> Results<UserPlayInfo>
+    func fetchFilter(_ query: String) -> Results<UserPlayInfo>
     func createPlay(_ item: UserPlayInfo)
     func updatePlay(_ item: UserPlayInfo)
     func deletePlay(_ item: UserPlayInfo)
-    
     func updateReview(_ item: UserPlayInfo)
 }
 
@@ -23,7 +30,22 @@ class UserPlayRepository {
     let localRealm = try! Realm()
     
     func fetch() -> Results<UserPlayInfo> {
-        return localRealm.objects(UserPlayInfo.self).sorted(byKeyPath: "date", ascending: false) // 항상 최신순
+        return localRealm.objects(UserPlayInfo.self).sorted(byKeyPath: "date", ascending: false) // 최신 순서
+    }
+    
+    func fetchWith(sort: SortOption, option: Bool) -> Results<UserPlayInfo> {
+        switch sort {
+        case .date, .title :
+            // 날짜, 또는 가나다 순
+            return localRealm.objects(UserPlayInfo.self).sorted(byKeyPath: sort.rawValue, ascending: option)
+        
+        case .userReview :
+            // 리뷰 있을 경우만
+            let predicate = NSPredicate(format: "#userReview.@count > 0")
+            return localRealm.objects(UserPlayInfo.self).filter(predicate)
+            
+        }
+        
     }
     
     func fetchFilter(_ query: String) -> Results<UserPlayInfo> {
@@ -33,9 +55,9 @@ class UserPlayRepository {
             $0.title.contains(query, options: .caseInsensitive) ||
             $0.place.contains(query, options: .caseInsensitive) ||
             $0.userReview.text.contains(query, options: .caseInsensitive) ||
-            $0.casts == query  // 캐스트 이름이 일치하면 검색가능 (일부로 할 경우 String 타입의 프로퍼티가 있는 오브젝트 클래스를 만들어야함) 
+            $0.casts == query  // 캐스트 이름이 일치하면 검색가능 (일부로 할 경우 String 타입의 프로퍼티가 있는 오브젝트 클래스를 만들어야함)
         }
-
+        
         return results
     }
     

--- a/YeonMuLog/Global/Literal/en.lproj/Localizable.strings
+++ b/YeonMuLog/Global/Literal/en.lproj/Localizable.strings
@@ -50,3 +50,10 @@
 
 // 검색
 "searchPlaceHolderText" = "Please enter a title";
+
+// 정렬
+"sortBy" = "Sort by";
+"sortByLatest" = "Latest";
+"sortByOldest" = "Oldest";
+"sortByAlphabetical" = "Alphabetical";
+"sortByReverseAlphabetical" = "Reverse Alphabetical";

--- a/YeonMuLog/Global/Literal/ko.lproj/Localizable.strings
+++ b/YeonMuLog/Global/Literal/ko.lproj/Localizable.strings
@@ -50,3 +50,10 @@
 
 // 검색
 "searchPlaceHolderText" = "극 제목으로 검색";
+
+// 정렬
+"sortBy" = "정렬";
+"sortByLatest" = "최신 순";
+"sortByOldest" = "오래된 순";
+"sortByAlphabetical" = "가나다 순";
+"sortByReverseAlphabetical" = "가나다 역순";

--- a/YeonMuLog/Presentations/Tarae/TaraeViewController.swift
+++ b/YeonMuLog/Presentations/Tarae/TaraeViewController.swift
@@ -53,14 +53,49 @@ class TaraeViewController: BaseViewController {
     
     override func setNavigationBar() {
         super.setNavigationBar()
-        
         navigationItem.title = "mainTabName".localized
         
-        let searchAndAdd = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(searchAndAddButtonTapped))
+        // 오른쪽 바버튼
+        let searchAndAdd = UIBarButtonItem(
+            barButtonSystemItem: .add,
+            target: self,
+            action: #selector(searchAndAddButtonTapped))
         searchAndAdd.tintColor = .black
         navigationItem.backButtonTitle = ""
         
         navigationItem.rightBarButtonItem = searchAndAdd
+        
+        // 왼쪽 바버튼
+        // - 정렬
+        let sortMenuItems: [UIAction] =  [
+            UIAction(title: "sortByLatest".localized, handler: { [weak self] _ in
+                self?.list = self?.repository.fetchWith(sort: .date, option: false)
+            }),
+            UIAction(title: "sortByOldest".localized, handler: { [weak self] _ in
+                self?.list = self?.repository.fetchWith(sort: .date, option: true)
+            }),
+            UIAction(title: "sortByAlphabetical".localized, handler: { [weak self] _ in
+                self?.list = self?.repository.fetchWith(sort: .title, option: true)
+            }),
+            UIAction(title: "sortByReverseAlphabetical".localized, handler: { [weak self] _ in
+                self?.list = self?.repository.fetchWith(sort: .title, option: false)
+            })
+            
+        ]
+    
+        let sortMenu = UIMenu(
+            title: "sortBy".localized,
+            image: nil,
+            identifier: nil,
+            options: [],
+            children: sortMenuItems)
+
+        let sort = UIBarButtonItem(
+            image: UIImage(systemName: "line.3.horizontal.decrease.circle"),
+            menu: sortMenu)
+        
+        navigationItem.leftBarButtonItems = [sort]
+
     }
     
     override func configure() {


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- feature/#108

### 💡 **Motivation**
날짜순, 극 가나다순으로 정렬버튼 만들기

### 🔑 **Key Changes**
- Realm Repository에 정렬해서 가져오는 메서드 추가
- 왼쪽 바버튼에 메뉴버튼 추가
- 최신,오래된순, 가나다순, 가나다역순 추가 

🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 정렬하기 | ![Simulator Screen Recording - iPhone 11 - 2022-10-29 at 18 21 46](https://user-images.githubusercontent.com/51395335/198823949-ba3f8843-5d7b-40d9-8a23-abad6cfc99cf.gif) |

### Relevant Issue(s)
- #108  
: 리뷰 갯수순을 만들어야함 
