### PR TITLE
[Feat] #112 관극기록 검색기능 추가

### DIFF
--- a/YeonMuLog/Global/Literal/en.lproj/Localizable.strings
+++ b/YeonMuLog/Global/Literal/en.lproj/Localizable.strings
@@ -57,3 +57,9 @@
 "sortByOldest" = "Oldest";
 "sortByAlphabetical" = "Alphabetical";
 "sortByReverseAlphabetical" = "Reverse Alphabetical";
+
+// 관극기록 검색
+"searchWatchedAlertTitle" = "Search Reviews";
+"searchWatchedAlertMessage" = "You can search by title, place, review content, and  cast";
+"searchWatchedAlertTextFieldPlaceHolder" = "Type here";
+"searchButtonTitle" = "Search";

--- a/YeonMuLog/Global/Literal/ko.lproj/Localizable.strings
+++ b/YeonMuLog/Global/Literal/ko.lproj/Localizable.strings
@@ -57,3 +57,9 @@
 "sortByOldest" = "오래된 순";
 "sortByAlphabetical" = "가나다 순";
 "sortByReverseAlphabetical" = "가나다 역순";
+
+// 관극기록 검색
+"searchWatchedAlertTitle" = "관극기록 검색";
+"searchWatchedAlertMessage" = "극 제목, 공연장소, 리뷰, 캐스팅으로 관극기록을 검색할 수 있습니다.";
+"searchWatchedAlertTextFieldPlaceHolder" = "검색어를 입력하세요";
+"searchButtonTitle" = "검색하기";

--- a/YeonMuLog/Presentations/Tarae/TaraeViewController.swift
+++ b/YeonMuLog/Presentations/Tarae/TaraeViewController.swift
@@ -94,8 +94,14 @@ class TaraeViewController: BaseViewController {
             image: UIImage(systemName: "line.3.horizontal.decrease.circle"),
             menu: sortMenu)
         
-        navigationItem.leftBarButtonItems = [sort]
-
+        // - 검색
+        let search = UIBarButtonItem(
+            barButtonSystemItem: .search,
+            target: self,
+            action: #selector(searchButtonTapped(_:)))
+        
+        navigationItem.leftBarButtonItems = [sort, search]
+        
     }
     
     override func configure() {
@@ -106,6 +112,56 @@ class TaraeViewController: BaseViewController {
         
         mainView.tableView.register(TaraeReviewTableViewCell.self, forCellReuseIdentifier: String(describing: TaraeReviewTableViewCell.self))
     }
+    // MARK: - Actions
+        @objc
+        func searchButtonTapped(_ sender: UIBarButtonItem) {
+            // 텍스트필드가 있는 얼럿을 띄우고 검색하기
+            let searchAlert = UIAlertController(
+                title: "searchWatchedAlertTitle".localized,
+                message: "searchWatchedAlertMessage".localized,
+                preferredStyle: .alert)
+            
+            let search = UIAlertAction(
+                title: "searchButtonTitle".localized,
+                style: .default) { [weak self] _ in
+                    var style = ToastStyle()
+                    style.backgroundColor = .CustomColor.purple30
+                    let fontColor = UIColor.CustomColor.purple800
+                    style.titleColor = fontColor
+                    style.messageColor = fontColor
+                    style.imageSize = CGSize(width: 80, height: 80)
+                    style.titleFont = .appleSDGothicNeo(of: .title, weight: .medium)
+                    style.messageFont = .appleSDGothicNeo(of: .subTitle, weight: .regular)
+                    
+                    // 검색어가 없을 시
+                    guard let text = searchAlert.textFields?[0].text, !text.isEmpty else {
+                        self?.view.makeToast("검색어를 제대로 입력해주세요", duration: 0.75, position: .center, title: nil, image: nil, style: style, completion: nil)
+                        return
+                    }
+                    // 검색결과가 없을 시
+                    guard let list = self?.repository.fetchFilter(text), !list.isEmpty else {
+                        self?.view.makeToast("\(text)에 해당하는 결과가 없습니다.", duration: 0.75, position: .center, title: nil, image: nil, style: style, completion: nil)
+                        return
+                    }
+                    // 검색결과를 리스트에 넣고, 알려줌
+                    self?.list = list
+                    self?.view.makeToast("\(text)에 해당하는 결과가 \(list.count)건 있습니다.", duration: 0.75, position: .center, title: nil, image: nil, style: style, completion: nil)
+                }
+            
+            let cancel = UIAlertAction(
+                title: "cancelButton".localized,
+                style: .cancel)
+            
+            searchAlert.addTextField { textField in
+                textField.placeholder = "searchWatchedAlertTextFieldPlaceHolder".localized
+            }
+            
+            searchAlert.addAction(search)
+            searchAlert.addAction(cancel)
+            
+            present(searchAlert, animated: true)
+            
+        }
 }
 
 // MARK: - Table View


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- feature/#112

### 💡 **Motivation**
관극기록 검색기능 추가

### 🔑 **Key Changes**
- 네비게이션 아이템 왼쪽에 추가 
- 검색어가 없을 때 토스트
- 검색결과가 없을 때 토스트
- 검색결과가 있을 경우 토스트 + 검색결과를 관극기록에 보여주기 
(검색결과는 극제목, 장소, 리뷰내용, 캐스팅(전부 일치)으로 검색 가능) 


🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 관극기록 검색 |  ![Simulator Screen Recording - iPhone 11 - 2022-10-29 at 20 33 39](https://user-images.githubusercontent.com/51395335/198829165-ed4c1b6e-10e0-451f-9fd2-a62f6eaef838.gif)  |

### Relevant Issue(s)
- #112
