### PR TITLE
[Feat] #96 좌석정보와 가격정보 유무에 따른 컨디셔널 렌더링

### DIFF
--- a/YeonMuLog/Presentations/TaraeDetail/TaraeDetailPlayInfoTableViewCell.swift
+++ b/YeonMuLog/Presentations/TaraeDetail/TaraeDetailPlayInfoTableViewCell.swift
@@ -107,8 +107,25 @@ class TaraeDetailPlayInfoTableViewCell: UITableViewCell {
         dateLabel.text = "\(data.date.playString())"
         castLabel.text = data.casts.joined(separator: ", ")
         placeLabel.text = data.place
-        seatAndTicketLabel.text = "\(data.seat) | \(data.ticket) 원"
+        
+        // 좌석과 가격 둘다 없을 경우 히든처리
+        if data.seat.isEmpty && data.ticket == 0 {
+            seatAndTicketLabel.isHidden = true
+            seatAndTicketImageView.isHidden = true
+        } else {
+            seatAndTicketLabel.isHidden = false
+            seatAndTicketImageView.isHidden = false
+            
+            if !data.seat.isEmpty && data.ticket > 0 {
+                seatAndTicketLabel.text = "\(data.seat) | \(data.ticket) 원"
+            } else if !data.seat.isEmpty && data.ticket == 0 {
+                seatAndTicketLabel.text = "\(data.seat)"
+            } else if data.seat.isEmpty && data.ticket > 0 {
+                seatAndTicketLabel.text = "\(data.ticket) 원"
+            }
+        }
         reviewCountLabel.text = "리뷰 \(data.userReview.count)"
+        reviewBackgroundView.isHidden = data.userReview.count == 0 ? true : false
     }
     
     // MARK: - UI


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- feat/#96

### 💡 **Motivation**
좌석정보와 가격정보 유무에 따른 컨디셔널 렌더링

### 🔑 **Key Changes**
아래 정보에 따라 컨디셔널 렌더링
- 좌석정보만 있을 때
- 가격정보만 있을 때
- 둘 다 있을 때와 없을 때


🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 좌석정보,가격정보에 따른 컨디셔널 렌더링 |  ![Simulator Screen Recording - iPhone 11 - 2022-10-29 at 21 01 07](https://user-images.githubusercontent.com/51395335/198830291-8a6fc9b2-ce72-4f1c-8349-2dc4dd5a6bb4.gif)  |

### Relevant Issue(s)
- #96
