### PR TITLE
[Design] #110 무드에 맞지 않은 컬러들을 커스텀 컬러로 수정

### DIFF
--- a/YeonMuLog/Presentations/AddWatched/TagCollectionViewCell.swift
+++ b/YeonMuLog/Presentations/AddWatched/TagCollectionViewCell.swift
@@ -41,12 +41,12 @@ class TagCollectionViewCell: UICollectionViewCell {
     }
     func defaultDesign() {
         self.backgroundColor = .systemGray6
-        tagLabel.textColor = .black
+        tagLabel.textColor = .systemGray2
     }
     
     func pressedDesign() {
-        self.backgroundColor = .systemPink
-        tagLabel.textColor = .white
+        self.backgroundColor = .CustomColor.castTagBGColor
+        tagLabel.textColor = .CustomColor.castTagFontColor
     }
     
     private func setConstraints() {

--- a/YeonMuLog/Presentations/AddWatched/WatchedPosterGenreTitleTableViewCell.swift
+++ b/YeonMuLog/Presentations/AddWatched/WatchedPosterGenreTitleTableViewCell.swift
@@ -24,7 +24,7 @@ final class WatchedPosterGenreTitleTableViewCell: UITableViewCell {
         $0.layer.cornerRadius = 8
         $0.layer.masksToBounds = true
         $0.textColor = .white
-        $0.backgroundColor = .systemPink
+        $0.backgroundColor = .CustomColor.musicalTagColor
     }
     
     private let titleLabel = UILabel().then {
@@ -52,6 +52,7 @@ final class WatchedPosterGenreTitleTableViewCell: UITableViewCell {
         let url = URL(string: data.poster)
         posterImageView.kf.setImage(with: url)
         genreLabel.text = "  \(data.genre)  "
+        genreLabel.backgroundColor = data.genre == "뮤지컬" ? .CustomColor.musicalTagColor : .CustomColor.playTagColor
     }
     
     // MARK: - UI

--- a/YeonMuLog/Presentations/Chart/NoChartTableViewCell.swift
+++ b/YeonMuLog/Presentations/Chart/NoChartTableViewCell.swift
@@ -11,7 +11,7 @@ class NoChartTableViewCell: UITableViewCell {
     // MARK: - Properties
     private let guideLabel = UILabel().then {
         $0.font = .appleSDGothicNeo(of: .subTitle, weight: .regular)
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.text = "NoChartAvailable".localized

--- a/YeonMuLog/Presentations/SearchPlay/AddPlayInfoTableViewCell.swift
+++ b/YeonMuLog/Presentations/SearchPlay/AddPlayInfoTableViewCell.swift
@@ -11,7 +11,7 @@ final class AddPlayInfoTableViewCell: UITableViewCell {
     // MARK: - Properties
     private let guideLabel = UILabel().then {
         $0.font = .appleSDGothicNeo(of: .subTitle, weight: .regular)
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.text = "AddPlayInfoLabel".localized

--- a/YeonMuLog/Presentations/SearchPlay/FirstSearchPlayTableViewCell.swift
+++ b/YeonMuLog/Presentations/SearchPlay/FirstSearchPlayTableViewCell.swift
@@ -11,7 +11,7 @@ final class FirstSearchPlayTableViewCell: UITableViewCell {
     // MARK: - Properties
     private let guideLabel = UILabel().then {
         $0.font = .appleSDGothicNeo(of: .subTitle, weight: .regular)
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.text = "FirstSearchLabel".localized

--- a/YeonMuLog/Presentations/SearchPlay/NoSearchResultTableViewCell.swift
+++ b/YeonMuLog/Presentations/SearchPlay/NoSearchResultTableViewCell.swift
@@ -11,7 +11,7 @@ class NoSearchResultTableViewCell: UITableViewCell {
     // MARK: - Properties
     private let guideLabel = UILabel().then {
         $0.font = .appleSDGothicNeo(of: .subTitle, weight: .regular)
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.text = "NoSearchResult".localized

--- a/YeonMuLog/Presentations/SearchPlay/SearchPlayResultTableViewCell.swift
+++ b/YeonMuLog/Presentations/SearchPlay/SearchPlayResultTableViewCell.swift
@@ -31,7 +31,7 @@ final class SearchPlayResultTableViewCell: UITableViewCell {
         $0.layer.cornerRadius = 8
         $0.layer.masksToBounds = true
         $0.textColor = .white
-        $0.backgroundColor = .systemPink
+        $0.backgroundColor = .CustomColor.musicalTagColor
     }
     
     private let titleLabel = UILabel().then {
@@ -95,6 +95,7 @@ final class SearchPlayResultTableViewCell: UITableViewCell {
         castLabel.text = data.cast
         placeLabel.text = data.place
         genreLabel.text = "  \(data.genre)  "
+        genreLabel.backgroundColor = data.genre == "뮤지컬" ? .CustomColor.musicalTagColor : .CustomColor.playTagColor
     }
     
     // MARK: - UI

--- a/YeonMuLog/Presentations/Tarae/NoReviewTableViewCell.swift
+++ b/YeonMuLog/Presentations/Tarae/NoReviewTableViewCell.swift
@@ -11,7 +11,7 @@ final class NoReviewTableViewCell: UITableViewCell {
     // MARK: - Properties
     private let guideLabel = UILabel().then {
         $0.font = .appleSDGothicNeo(of: .subTitle, weight: .regular)
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.text = "NoReview".localized

--- a/YeonMuLog/Presentations/Tarae/TaraeReviewTableViewCell.swift
+++ b/YeonMuLog/Presentations/Tarae/TaraeReviewTableViewCell.swift
@@ -34,18 +34,18 @@ final class TaraeReviewTableViewCell: UITableViewCell {
     private let reviewBackgroundView = UIView().then {
         $0.layer.cornerRadius = 6
         $0.clipsToBounds = true
-        $0.backgroundColor = .systemGray6
+        $0.backgroundColor = .CustomColor.reviewBGColor
     }
     
     private let reviewIconImageView = UIImageView().then {
         $0.image = UIImage(systemName: "quote.bubble")
-        $0.tintColor = .purple
+        $0.tintColor = .CustomColor.purple500
         $0.preferredSymbolConfiguration = .init(pointSize: 11)
         $0.contentMode = .scaleAspectFit
         
     }
     private let reviewLabel = UILabel().then {
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.font = .appleSDGothicNeo(of: .content, weight: .medium)
         $0.text = "리뷰 0"
         $0.adjustsFontSizeToFitWidth = true

--- a/YeonMuLog/Presentations/TaraeDetail/NoReviewCollectionViewCell.swift
+++ b/YeonMuLog/Presentations/TaraeDetail/NoReviewCollectionViewCell.swift
@@ -11,7 +11,7 @@ class NoReviewCollectionViewCell: UICollectionViewCell {
     // MARK: - Properties
     private let guideLabel = UILabel().then {
         $0.font = .appleSDGothicNeo(of: .subTitle, weight: .regular)
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.text = "NoUserReview".localized

--- a/YeonMuLog/Presentations/TaraeDetail/TaraeDetailPlayInfoTableViewCell.swift
+++ b/YeonMuLog/Presentations/TaraeDetail/TaraeDetailPlayInfoTableViewCell.swift
@@ -20,17 +20,17 @@ class TaraeDetailPlayInfoTableViewCell: UITableViewCell {
     private let reviewBackgroundView = UIView().then {
         $0.layer.cornerRadius = 6
         $0.clipsToBounds = true
-        $0.backgroundColor = .systemGray6
+        $0.backgroundColor = .CustomColor.reviewBGColor
     }
     private let reviewIconImageView = UIImageView().then {
         $0.image = UIImage(systemName: "quote.bubble")
-        $0.tintColor = .purple
+        $0.tintColor = .CustomColor.purple500
         $0.preferredSymbolConfiguration = .init(pointSize: 11)
         $0.contentMode = .scaleAspectFit
         
     }
     private let reviewCountLabel = UILabel().then {
-        $0.textColor = .purple
+        $0.textColor = .CustomColor.purple500
         $0.font = .appleSDGothicNeo(of: .content, weight: .medium)
         $0.text = "리뷰 0"
     }

--- a/YeonMuLog/Utils/setColor.swift
+++ b/YeonMuLog/Utils/setColor.swift
@@ -18,6 +18,17 @@ extension UIColor {
         static let purple600 = #colorLiteral(red: 0.3882352941, green: 0.1882352941, blue: 0.6509803922, alpha: 1)
         static let purple800 = #colorLiteral(red: 0.2745098039, green: 0.1176470588, blue: 0.4745098039, alpha: 1)
         
+        // - 리뷰 셀 배경컬러
+        static let reviewBGColor = #colorLiteral(red: 0.9725490196, green: 0.9568627451, blue: 1, alpha: 1)
+        
+        // - 장르 태그 컬러
+        static let musicalTagColor = #colorLiteral(red: 0.5594159961, green: 0.4652210474, blue: 1, alpha: 1)
+        static let playTagColor = #colorLiteral(red: 0.9013746381, green: 0.4565898776, blue: 1, alpha: 1)
+        
+        // - 캐스팅 태그 컬러
+        static let castTagBGColor = #colorLiteral(red: 0.8901960784, green: 0.8, blue: 1, alpha: 1)
+        static let castTagFontColor = #colorLiteral(red: 0.4274509804, green: 0, blue: 0.9764705882, alpha: 1)
+        
         // #colorLiteral(red:  , green: , blue: , alpha: )
     }
 }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- design/#110

### 💡 **Motivation**
무드에 맞지 않은 컬러들을 커스텀 컬러로 수정

### 🔑 **Key Changes**
- 연극, 뮤지컬 태그 색상
- 캐스팅 선택 색상 
- 빈 정보일 때 안내 레이블 색상(관극기록 없을 때, 리뷰 없을 때, 통계없을 때, 검색결과창, 검색결과 없을 때 등)


🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 바뀐 UI 색상들 |  ![Simulator Screen Recording - iPhone 11 - 2022-10-29 at 21 34 45](https://user-images.githubusercontent.com/51395335/198831861-17becc02-14b6-425d-a2e8-cbb3b22234ab.gif)  |

### Relevant Issue(s)
- #110
