### PR TITLE
[Fix] #123 통계 탭 다국어 대응

### DIFF
--- a/YeonMuLog/Global/Literal/en.lproj/Localizable.strings
+++ b/YeonMuLog/Global/Literal/en.lproj/Localizable.strings
@@ -63,3 +63,21 @@
 "searchWatchedAlertMessage" = "You can search by title, place, review content, and  cast";
 "searchWatchedAlertTextFieldPlaceHolder" = "Type here";
 "searchButtonTitle" = "Search";
+
+// 통계
+// - 요일수
+"Mon" = "Mon";
+"Tue" = "Tue";
+"Wed" = "Wed";
+"Thu" = "Thu";
+"Fri" = "Fri";
+"Sat" = "Sat";
+"Sun" = "Sun";
+"DaysOfTheWeek" = "Days of the week";
+"theMostWatched" = "📆 You saw the most shows on %@";
+"NumberOftheWatched" = ", %d times";
+
+// - 리뷰수
+"theMostReviewedIs" = "✍️ The show with the most reviews was %@";
+"NumberOfReviews" = "Number of reviews";
+"NumberOfReviewsWritten" = ", with a total of %d reviews.";

--- a/YeonMuLog/Global/Literal/ko.lproj/Localizable.strings
+++ b/YeonMuLog/Global/Literal/ko.lproj/Localizable.strings
@@ -1,9 +1,8 @@
-/* 
+/*
   Localizable.strings
   YeonMuLog
 
   Created by Doy Kim on 2022/09/15.
-  
 */
 
 "AddPlayInfoLabel" = "혹시 원하는 극 정보가 없으신가요?\n직접 입력해보세요!";
@@ -63,3 +62,21 @@
 "searchWatchedAlertMessage" = "극 제목, 공연장소, 리뷰, 캐스팅으로 관극기록을 검색할 수 있습니다.";
 "searchWatchedAlertTextFieldPlaceHolder" = "검색어를 입력하세요";
 "searchButtonTitle" = "검색하기";
+
+// 통계
+// - 요일수
+"Mon" = "월";
+"Tue" = "화";
+"Wed" = "수";
+"Thu" = "목";
+"Fri" = "금";
+"Sat" = "토";
+"Sun" = "일";
+"DaysOfTheWeek" = "요일";
+"theMostWatched" = "📆 극을 제일 많이 본 요일은\n%@요일로 ";
+"NumberOftheWatched" = "총 %d번 관극하였습니다.";
+
+// - 리뷰수
+"theMostReviewedIs" = "✍️ 리뷰를 제일 많이 쓴 극은\n%@(으)로 ";
+"NumberOfReviews" = "리뷰 수";
+"NumberOfReviewsWritten" = "총 %d개의 리뷰를 썼습니다.";

--- a/YeonMuLog/Presentations/Chart/ChartView.swift
+++ b/YeonMuLog/Presentations/Chart/ChartView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class ChartView: BaseView {
     lazy var tableView = UITableView().then {
-        $0.contentInset = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
         $0.separatorColor = .clear
         $0.sectionHeaderTopPadding = .zero
     }

--- a/YeonMuLog/Presentations/Chart/ChartViewController.swift
+++ b/YeonMuLog/Presentations/Chart/ChartViewController.swift
@@ -128,19 +128,22 @@ extension ChartViewController {
             let dataEntry = BarChartDataEntry(x: Double(index), y: reviewNumber[index])
             dataEntries.append(dataEntry)
         }
-        let chartDataSet = BarChartDataSet(entries: dataEntries, label: "리뷰 수")
-        let title = "✍️ 리뷰를 제일 많이 쓴 극은\n\(play[reviewNumber.firstIndex(of: reviewNumber.max()!)!])(으)로 총 \(Int(reviewNumber.max()!))개의 리뷰를 썼습니다."
+        
+        let chartDataSet = BarChartDataSet(entries: dataEntries, label: "NumberOfReviews".localized)
+        let title = "theMostReviewedIs".localized(with: play[reviewNumber.firstIndex(of: reviewNumber.max()!)!]) + "NumberOfReviewsWritten".localized(number: Int(reviewNumber.max()!))
+
         return (chartDataSet, title, play)
     }
     
     func dateBarChartDataSet() -> (BarChartDataSet, String, [String]) {
-        let date: [String] = ["월", "화", "수", "목", "금", "토"]
-        var watched: [Double] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        let date: [String] = ["Mon".localized, "Tue".localized, "Wed".localized, "Thu".localized, "Fri".localized, "Sat".localized, "Sun".localized]
+        let dateForCalculation: [String] = ["월","화","수","목","금","토","일"]
+        var watched: [Double] = [0, 0, 0, 0, 0, 0, 0]
         
         if let list = list {
             list.forEach {
                 for index in 0..<date.count {
-                    if $0.date.extractDate() == date[index] {
+                    if $0.date.extractDate() == dateForCalculation[index] {
                         watched[index] += 1.0
                     }
                 }
@@ -153,8 +156,13 @@ extension ChartViewController {
             let dataEntry = BarChartDataEntry(x: Double(index), y: watched[index])
             dataEntries.append(dataEntry)
         }
-        let chartDataSet = BarChartDataSet(entries: dataEntries, label: "요일")
-        let title = "📆 극을 제일 많이 본 요일은\n\(date[watched.firstIndex(of: watched.max()!)!])요일로 총 \(Int(watched.max()!))번 관극하였습니다."
+        
+        let chartDataSet = BarChartDataSet(entries: dataEntries, label: "DaysOfTheWeek".localized)
+        
+        let chartData = BarChartData(dataSet: chartDataSet)
+        
+        let title = "theMostWatched".localized(with: date[watched.firstIndex(of: watched.max()!)!]) + "NumberOftheWatched".localized(number: Int(watched.max()!))
+        
         return (chartDataSet, title, date)
     }
 }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- fix/#123

### 💡 **Motivation**
통계 탭 다국어 대응

### 🔑 **Key Changes**
- 일요일 추가 
- 영어,한국어 다국어 대응
- 날짜의 경우 한국날짜라서 통계의 요일계산을 위한 한국어 요일 배열 추가 
(* 언어설정이 영어일때도 캘린더 설정을 영어로 바꿔서 이 부분을 코드가 아니라 자동으로 대응할 수 있도록 하기) 


🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
|  영어가 주 언어일 때 통계 탭 |  ![IMG_0116](https://user-images.githubusercontent.com/51395335/199913882-e2998602-afa9-471a-864f-af2bc1f4b89b.PNG)  |
|   |  ![IMG_0117](https://user-images.githubusercontent.com/51395335/199913865-40d3ba7d-b3ba-4fd8-95c8-8c497dba53e6.PNG) |
### Relevant Issue(s)
- #123
