### PR TITLE
[Feature] #95 캐스팅 정보 유무에 따른 컨디셔널 렌더링

### DIFF
--- a/YeonMuLog/Presentations/AddWatched/AddWatchedViewController.swift
+++ b/YeonMuLog/Presentations/AddWatched/AddWatchedViewController.swift
@@ -41,7 +41,11 @@ class AddWatchedViewController: BaseViewController {
     let mainView = AddWatchedView()
     let repository = UserPlayRepository.shared
     var playInfo: Play? 
-    var castArray: [String] = []
+    var castArray: [String] = [] {
+        didSet {
+            mainView.tableView.reloadData()
+        }
+    }
     var castSelectedIndex: [Int] = []
     var castSelectedData: [String] = []
         
@@ -178,6 +182,8 @@ class AddWatchedViewController: BaseViewController {
     }
     
     override func configure() {
+        calculateCastInfo()
+        
         mainView.tableView.delegate = self
         mainView.tableView.dataSource = self
         
@@ -186,6 +192,22 @@ class AddWatchedViewController: BaseViewController {
         mainView.tableView.register(WatchedTextFieldTableViewCell.self, forCellReuseIdentifier: String(describing: WatchedTextFieldTableViewCell.self))
         
         mainView.tableView.register(WatchedTagsTableViewCell.self, forCellReuseIdentifier: String(describing: WatchedTagsTableViewCell.self))
+    }
+    /// 캐스팅 정보 문자열을 가져와 배우별로 잘라서 배열에 넣는 메서드
+    func calculateCastInfo() {
+        guard let play = playInfo else { return }
+        
+        if  !play.cast.trimmingCharacters(in: .whitespaces).isEmpty {
+            castArray = play.cast.components(separatedBy: ", ")
+            castArray = castArray.map {
+               $0.replacingOccurrences(of: " 등", with: "")
+            }
+        } else {
+            let noCast = ["noCast".localized]
+            castArray = noCast
+            castSelectedData = noCast
+            castSelectedIndex.append(0)
+       }
     }
 }
 
@@ -281,7 +303,7 @@ extension AddWatchedViewController: UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return indexPath.row == 3 ? 140 : UITableView.automaticDimension
+       return indexPath.row == 3 ? (castArray.count > 4 ? 140 : 90) : UITableView.automaticDimension
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -324,21 +346,7 @@ extension AddWatchedViewController: UICollectionViewDelegateFlowLayout, UICollec
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         
-        guard let play = playInfo else { return 0 }
-        
-        if  !play.cast.trimmingCharacters(in: .whitespaces).isEmpty {
-            castArray = play.cast.components(separatedBy: ", ")
-            castArray = castArray.map {
-               $0.replacingOccurrences(of: " 등", with: "")
-            }
-            return castArray.count
-        } else {
-            let noCast = ["noCast".localized]
-            castArray = noCast
-            castSelectedData = noCast
-            castSelectedIndex.append(0)
-            return castArray.count
-        }
+        return castArray.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/YeonMuLog/Presentations/SearchPlay/SearchPlayResultTableViewCell.swift
+++ b/YeonMuLog/Presentations/SearchPlay/SearchPlayResultTableViewCell.swift
@@ -92,7 +92,7 @@ final class SearchPlayResultTableViewCell: UITableViewCell {
         let url = URL(string: data.poster)
         posterImageView.kf.setImage(with: url)
         dateLabel.text = "\(data.startDate) ~ \(data.endDate)"
-        castLabel.text = data.cast
+        castLabel.text = data.cast.trimmingCharacters(in: .whitespaces).isEmpty ? "정보 없음" : data.cast
         placeLabel.text = data.place
         let genre = data.genre == "뮤지컬" ? "tagMusical".localized : "tagPlay".localized
         genreLabel.text = "  \(genre)  "


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- feature/#95

### 💡 **Motivation**
캐스팅 정보 유무에 따른 컨디셔널 렌더링

### 🔑 **Key Changes**
- 검색결과에서 캐스팅이 없을 경우, 빈칸 대신 '정보 없음'을 보여줌 
- 관극추가하기 화면에서 캐스팅 정보에 따라 최대 두줄이 될 경우와 1줄일 경우 여백이 맞도록 수정

🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 검색화면 |  ![IMG_0222](https://user-images.githubusercontent.com/51395335/200185056-51129a89-e232-428c-87a4-4fccd25c6b0f.PNG) |
| 관극추가하기(1줄) | ![IMG_0223](https://user-images.githubusercontent.com/51395335/200185062-55afe486-feac-4fc9-a204-5ee7e4d0f51e.PNG)  |
| (2줄)   |  ![IMG_0224](https://user-images.githubusercontent.com/51395335/200185080-571b0b74-14ed-4b1a-9735-ca868663beb0.PNG)  |

### Relevant Issue(s)
- not fully resolved: #95
