### PR TITLE
[Design] #135 리뷰 테이블뷰의 셀과 버튼 위치 조정

### DIFF
--- a/YeonMuLog/Presentations/TaraeDetail/TaraeDetailReviewTableViewCell.swift
+++ b/YeonMuLog/Presentations/TaraeDetail/TaraeDetailReviewTableViewCell.swift
@@ -57,7 +57,7 @@ final class TaraeDetailReviewTableViewCell: UITableViewCell {
         chatLabel.snp.makeConstraints { make in
             make.top.equalTo(dateLabel).offset(4)
             make.leading.equalTo(dateLabel.snp.trailing).offset(8)
-            make.width.lessThanOrEqualToSuperview().multipliedBy(0.58)
+            make.trailing.lessThanOrEqualToSuperview().inset(72)
             make.bottom.equalToSuperview()
         }
         bubbleBackgroundView.snp.makeConstraints { make in

--- a/YeonMuLog/Presentations/TaraeDetail/TaraeDetailView.swift
+++ b/YeonMuLog/Presentations/TaraeDetail/TaraeDetailView.swift
@@ -42,19 +42,19 @@ final class TaraeDetailView: BaseView {
     
     override func setConstraints() {
         tableView.snp.makeConstraints { make in
-            make.top.equalTo(self.safeAreaLayoutGuide)
+            make.top.equalTo(safeAreaLayoutGuide)
             make.leading.trailing.bottom.equalToSuperview()
         }
         
         addReviewButton.snp.makeConstraints { make in
             make.width.height.equalTo(48)
-            make.trailing.equalToSuperview().inset(20)
-            make.bottom.equalTo(self.safeAreaLayoutGuide)
+            make.trailing.equalTo(safeAreaLayoutGuide).inset(10)
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(10)
         }
         
         goUpbutton.snp.makeConstraints { make in
             make.width.height.equalTo(48)
-            make.trailing.equalToSuperview().inset(20)
+            make.trailing.equalTo(addReviewButton)
             make.bottom.equalTo(addReviewButton.snp.top).offset(-8)
         }
     }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- design/#135

### 💡 **Motivation**
리뷰 테이블뷰의 셀과 버튼 위치 조정

### 🔑 **Key Changes**
- 테이블 뷰 셀의 width 비율값을 trailing 상수값으로 변경
- 버튼 trailing, bottom 값을 변경 

🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 변경후 | ![Simulator Screen Shot - iPhone 11 - 2022-12-08 at 02 13 28](https://user-images.githubusercontent.com/51395335/206249438-e2864444-e0cd-4c60-bdc1-c518380a46bc.png)|

### Relevant Issue(s)
- Closes #135
